### PR TITLE
修复条件卡片 点击异常

### DIFF
--- a/src/components/nodeWrap.vue
+++ b/src/components/nodeWrap.vue
@@ -1055,6 +1055,10 @@ export default {
         },
         delTerm(index) {
             this.nodeConfig.conditionNodes.splice(index, 1)
+            this.nodeConfig.conditionNodes.map((item, index) => {
+                item.priorityLevel = index + 1
+                item.nodeName = `条件${index + 1}`
+            });
             for (var i = 0; i < this.nodeConfig.conditionNodes.length; i++) {
                 this.nodeConfig.conditionNodes[i].error = this.conditionStr(this.nodeConfig.conditionNodes[i], i) == "请设置条件" && i != this.nodeConfig.conditionNodes.length - 1
             }


### PR DESCRIPTION
点击添加条件按钮后，删除中间条件卡片，再点击最右边的条件卡片 ，会报错，打不开条件抽屉。

这个bug帮你修复了